### PR TITLE
Email function embedded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 .DS_Store
 *.pem
 yarn.lock
+package-lock.json
 
 # debug
 npm-debug.log*

--- a/components/generator/array/arrayGeneratorFunc.js
+++ b/components/generator/array/arrayGeneratorFunc.js
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import toast from "react-hot-toast";
 import { sendConfirmation } from "@/lib/api";
+"use client";
+import { useUser } from "@clerk/nextjs";
 
 const ArrayGeneratorFunc = () => {
   const [minValue, setMinValue] = useState(-100);
@@ -88,37 +90,49 @@ const ArrayGeneratorFunc = () => {
         break;
     }
   };
-  let Success=false;
-  const Generate= async() =>{
-    if (Success){
-      let value={"value":"Test Case Generated Successfully!!!"}
+  const { user } = useUser();
+  let send=false;
+  const generateMail= async(valuesString) =>{
+    let email=user.primaryEmailAddress.emailAddress;
+    if (send){
+      const value={
+        "email": email,
+        "textcontent": valuesString,
+        "filename": "generated_values.txt",
+        "content":valuesString,
+        "value":"Test Case Generated Successfully!!!"
+      }
       try{
         await sendConfirmation(value);
       }
       catch(error){
+        toast.error("Couldn't send mail!!");
       }
     }
     else{
-      let value={"value":"Some Error Occured!!!"}
+      const value={
+        "email": email,
+        "value":"Couldn't generate testacases!!"
+      }
       try{
         await sendConfirmation(value);
       }
       catch(error){
-        console.log("ERROR")
+        toast.error("Couldn't send mail!!");
       }
     }
   }
   const handleGenerateValues = async () => {
     setIsLoading(true); // set isLoading to true
     const errorOccurred = false; // add this flag variable
-
+    let newValues=[];
     try {
       await toast.promise(
         new Promise((resolve, reject) => {
           // add reject parameter to the promise
           setTimeout(() => {
             const startTime = performance.now();
-            let newValues = Array.from({ length: numArrays }, (_, index) => {
+            newValues = Array.from({ length: numArrays }, (_, index) => {
               const size = randomSize
                 ? Math.floor(Math.random() * arraySize) + 1
                 : arraySize;
@@ -226,8 +240,8 @@ const ArrayGeneratorFunc = () => {
         {
           loading: "Generating values...",
           success: (success)=>{
-            Success=true;
-            return "Values generated successfully and mail sent!";
+            send=true;
+            return "Values generated successfully!!";
           },
           error: (error) => {
             if (errorOccurred) {
@@ -242,8 +256,23 @@ const ArrayGeneratorFunc = () => {
     } catch (error) {
       toast.error(error.message);
     }
+    const totalCases = advanceOptions.includes("Show Total Cases")
+      ? `${numArrays}\n`
+      : "";
+    const valuesString = newValues
+      .map((array) => {
+        const lengthString = advanceOptions.includes("Hide Array Size")
+          ? ""
+          : `${array.length}\n`;
+        if (advanceOptions.includes("Hide Commas")) {
+          return totalCases + lengthString + array.join(" ");
+        } else {
+          return totalCases + lengthString + array.join(", ");
+        }
+      })
+      .join("\n");
     setIsLoading(false); // set isLoading to false
-    await Generate();
+    await generateMail(valuesString);
   };
 
   const handleCopyValues = () => {

--- a/components/generator/array/arrayGeneratorFunc.js
+++ b/components/generator/array/arrayGeneratorFunc.js
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import toast from "react-hot-toast";
+import { sendConfirmation } from "@/lib/api";
 
 const ArrayGeneratorFunc = () => {
   const [minValue, setMinValue] = useState(-100);
@@ -87,7 +88,26 @@ const ArrayGeneratorFunc = () => {
         break;
     }
   };
-
+  let Success=false;
+  const Generate= async() =>{
+    if (Success){
+      let value={"value":"Test Case Generated Successfully!!!"}
+      try{
+        await sendConfirmation(value);
+      }
+      catch(error){
+      }
+    }
+    else{
+      let value={"value":"Some Error Occured!!!"}
+      try{
+        await sendConfirmation(value);
+      }
+      catch(error){
+        console.log("ERROR")
+      }
+    }
+  }
   const handleGenerateValues = async () => {
     setIsLoading(true); // set isLoading to true
     const errorOccurred = false; // add this flag variable
@@ -205,7 +225,10 @@ const ArrayGeneratorFunc = () => {
         }),
         {
           loading: "Generating values...",
-          success: "Values generated successfully!",
+          success: (success)=>{
+            Success=true;
+            return "Values generated successfully and mail sent!";
+          },
           error: (error) => {
             if (errorOccurred) {
               // show toast error if flag variable is true
@@ -220,6 +243,7 @@ const ArrayGeneratorFunc = () => {
       toast.error(error.message);
     }
     setIsLoading(false); // set isLoading to false
+    await Generate();
   };
 
   const handleCopyValues = () => {

--- a/components/generator/graph/graphGeneratorFunc.js
+++ b/components/generator/graph/graphGeneratorFunc.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { sendConfirmation } from "@/lib/api";
 import { DataSet } from "vis-data";
 import toast from "react-hot-toast";
 
@@ -44,7 +45,26 @@ const GraphGeneratorFunc = () => {
     const { value } = event.target;
     setAdvanceOptions(value);
   };
-
+  let Success=false;
+  const Generate= async() =>{
+    if (Success){
+      let value={"value":"Test Case Generated Successfully!!!"}
+      try{
+        await sendConfirmation(value);
+      }
+      catch(error){
+      }
+    }
+    else{
+      let value={"value":"Some Error Occured!!!"}
+      try{
+        await sendConfirmation(value);
+      }
+      catch(error){
+        console.log("ERROR")
+      }
+    }
+  }
   const handleGenerateValues = async (numGraphs) => {
     setIsLoading(true); // set isLoading to true
     const errorOccurred = false; // add this flag variable
@@ -205,7 +225,10 @@ const GraphGeneratorFunc = () => {
         }),
         {
           loading: "Generating values...",
-          success: "Values generated successfully!",
+          success: (success)=>{
+            Success=true;
+            return "Values generated successfully and mail sent!";
+          },
           error: (error) => {
             if (errorOccurred) {
               // show toast error if flag variable is true
@@ -220,6 +243,7 @@ const GraphGeneratorFunc = () => {
       toast.error(error.message);
     }
     setIsLoading(false); // set isLoading to false
+    await Generate();
   };
 
   const handleCopyGraphs = () => {

--- a/components/generator/integer/integerGeneratorFunc.js
+++ b/components/generator/integer/integerGeneratorFunc.js
@@ -1,3 +1,4 @@
+import { sendConfirmation } from "@/lib/api";
 import { useState } from "react";
 import toast from "react-hot-toast";
 
@@ -19,7 +20,26 @@ const IntegerGeneratorFunc = () => {
     const { value } = event.target;
     setAdvanceOptions(value);
   };
-
+  let Success=false;
+  const Generate= async() =>{
+    if (Success){
+      let value={"value":"Test Case Generated Successfully!!!"}
+      try{
+        await sendConfirmation(value);
+      }
+      catch(error){
+      }
+    }
+    else{
+      let value={"value":"Some Error Occured!!!"}
+      try{
+        await sendConfirmation(value);
+      }
+      catch(error){
+        console.log("ERROR")
+      }
+    }
+  }
   const handleGenerateValues = async () => {
     setIsLoading(true); // set isLoading to true
     const errorOccurred = false; // add this flag variable
@@ -55,7 +75,10 @@ const IntegerGeneratorFunc = () => {
         }),
         {
           loading: "Generating values...",
-          success: "Values generated successfully!",
+          success: (success)=>{
+            Success=true;
+            return "Values generated successfully and mail sent!";
+          },
           error: (error) => {
             if (errorOccurred) {
               // show toast error if flag variable is true
@@ -70,6 +93,7 @@ const IntegerGeneratorFunc = () => {
       toast.error(error.message);
     }
     setIsLoading(false); // set isLoading to false
+    await Generate();
   };
 
   const handleCopyValues = () => {

--- a/components/generator/linkedList/linkedListGeneratorFunc.js
+++ b/components/generator/linkedList/linkedListGeneratorFunc.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import toast from "react-hot-toast";
+import { sendConfirmation } from "@/lib/api";
 
 const LinkedListGeneratorFunc = () => {
   const [headValue, setHeadValue] = useState(0);
@@ -39,7 +40,26 @@ const LinkedListGeneratorFunc = () => {
     const { value } = event.target;
     setAdvanceOptions(value);
   };
-
+  let Success=false;
+  const Generate= async() =>{
+    if (Success){
+      let value={"value":"Test Case Generated Successfully!!!"}
+      try{
+        await sendConfirmation(value);
+      }
+      catch(error){
+      }
+    }
+    else{
+      let value={"value":"Some Error Occured!!!"}
+      try{
+        await sendConfirmation(value);
+      }
+      catch(error){
+        console.log("ERROR")
+      }
+    }
+  }
   const handleUpdateGenerateValues = async () => {
     setIsLoading(true); // set isLoading to true
     const errorOccurred = false; // add this flag variable
@@ -133,7 +153,10 @@ const LinkedListGeneratorFunc = () => {
         }),
         {
           loading: "Generating values...",
-          success: "Values generated successfully!",
+          success: (success)=>{
+            Success=true;
+            return "Values generated successfully and mail sent!";
+          },
           error: (error) => {
             if (errorOccurred) {
               // show toast error if flag variable is true
@@ -148,6 +171,7 @@ const LinkedListGeneratorFunc = () => {
       toast.error(error.message);
     }
     setIsLoading(false); // set isLoading to false
+    await Generate();
   };
 
   const handleAddGenerateValues = async () => {

--- a/components/generator/palindrome/palindromeGeneratorFunc.js
+++ b/components/generator/palindrome/palindromeGeneratorFunc.js
@@ -1,5 +1,5 @@
 import { useState } from "react";
-
+import { sendConfirmation } from "@/lib/api";
 import toast from "react-hot-toast";
 
 const PalindromeGeneratorFunc = () => {
@@ -43,7 +43,26 @@ const PalindromeGeneratorFunc = () => {
     const { value } = event.target;
     setAdvanceOptions(value);
   };
-
+  let Success=false;
+  const Generate= async() =>{
+    if (Success){
+      let value={"value":"Test Case Generated Successfully!!!"}
+      try{
+        await sendConfirmation(value);
+      }
+      catch(error){
+      }
+    }
+    else{
+      let value={"value":"Some Error Occured!!!"}
+      try{
+        await sendConfirmation(value);
+      }
+      catch(error){
+        console.log("ERROR")
+      }
+    }
+  }
   const handleGenerateValues = async () => {
     setIsLoading(true); // set isLoading to true
     const errorOccurred = false; // add this flag variable
@@ -245,7 +264,10 @@ const PalindromeGeneratorFunc = () => {
         }),
         {
           loading: "Generating values...",
-          success: "Values generated successfully!",
+          success: (success)=>{
+            Success=true;
+            return "Values generated successfully and mail sent!";
+          },
           error: (error) => {
             if (errorOccurred) {
               // show toast error if flag variable is true
@@ -260,6 +282,7 @@ const PalindromeGeneratorFunc = () => {
       toast.error(error.message);
     }
     setIsLoading(false); // set isLoading to false
+    await Generate();
   };
 
   const handleCopyValues = () => {

--- a/components/generator/string/stringGeneratorFunc.js
+++ b/components/generator/string/stringGeneratorFunc.js
@@ -1,5 +1,5 @@
 import { useState } from "react";
-
+import { sendConfirmation } from "@/lib/api";
 import toast from "react-hot-toast";
 
 const StringGeneratorFunc = () => {
@@ -64,7 +64,26 @@ const StringGeneratorFunc = () => {
         break;
     }
   };
-
+  let Success=false;
+  const Generate= async() =>{
+    if (Success){
+      let value={"value":"Test Case Generated Successfully!!!"}
+      try{
+        await sendConfirmation(value);
+      }
+      catch(error){
+      }
+    }
+    else{
+      let value={"value":"Some Error Occured!!!"}
+      try{
+        await sendConfirmation(value);
+      }
+      catch(error){
+        console.log("ERROR")
+      }
+    }
+  }
   const handleGenerateStrings = async () => {
     setIsLoading(true); // set isLoading to true
     const errorOccurred = false; // add this flag variable
@@ -176,7 +195,10 @@ const StringGeneratorFunc = () => {
         }),
         {
           loading: "Generating values...",
-          success: "Values generated successfully!",
+          success: (success)=>{
+            Success=true;
+            return "Values generated successfully and mail sent!";
+          },
           error: (error) => {
             if (errorOccurred) {
               // show toast error if flag variable is true
@@ -191,6 +213,7 @@ const StringGeneratorFunc = () => {
       toast.error(error.message);
     }
     setIsLoading(false); // set isLoading to false
+    await Generate();
   };
 
   const handleCopyStrings = () => {

--- a/config/nodemailer.js
+++ b/config/nodemailer.js
@@ -1,0 +1,14 @@
+import nodemailer from "nodemailer"
+export const transporter= nodemailer.createTransport({
+    service: 'gmail',
+    auth:{
+        user:process.env.EMAIL,
+        pass:process.env.PASS,
+    }
+
+});
+
+export const mailOptions={
+    from:"vivekkr694@gmail.com",
+    to:"vivekkr694@gmail.com",
+}

--- a/config/nodemailer.js
+++ b/config/nodemailer.js
@@ -1,9 +1,11 @@
 import nodemailer from "nodemailer"
 export const transporter= nodemailer.createTransport({
-    service: 'gmail',
-    auth:{
-        user:process.env.EMAIL,
-        pass:process.env.PASS,
-    }
+    host: "smtppro.zoho.in", 
+    secure: true, 
+    port: 465, 
+    auth: { 
+        user: process.env.EMAIL_SENDER, 
+        pass: process.env.EMAIL_PASSWORD, 
+    },
 
 });

--- a/config/nodemailer.js
+++ b/config/nodemailer.js
@@ -7,8 +7,3 @@ export const transporter= nodemailer.createTransport({
     }
 
 });
-
-export const mailOptions={
-    from:"vivekkr694@gmail.com",
-    to:"vivekkr694@gmail.com",
-}

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,3 +1,5 @@
+import toast from "react-hot-toast";
+
 export const sendConfirmation = async (data)=> fetch("/api/confirm",{
     method:"POST",
     body: JSON.stringify(data),
@@ -6,6 +8,11 @@ export const sendConfirmation = async (data)=> fetch("/api/confirm",{
         Accept: "application/json",
     }
 }).then((res)=>{
-    if (res.status!=200) alert ("Couldn't send mail!!");
+    if (!(res.status>=200 && res.status<300)) {
+        toast.error("Couldn't send mail!!")
+    }
+    else{
+        toast.success("Message Sent Successfully!!")
+    }
     return res.json();
 })

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,0 +1,11 @@
+export const sendConfirmation = async (data)=> fetch("/api/confirm",{
+    method:"POST",
+    body: JSON.stringify(data),
+    headers:{
+        "Content-Type":"application/json",
+        Accept: "application/json",
+    }
+}).then((res)=>{
+    if (res.status!=200) alert ("Couldn't send mail!!");
+    return res.json();
+})

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "logrocket": "^4.0.0",
     "nanoid": "^3.3.7",
     "next": "13.2.4",
+    "nodemailer": "^6.9.7",
     "react": "18.2.0",
     "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "18.2.0",

--- a/pages/api/confirm.js
+++ b/pages/api/confirm.js
@@ -1,0 +1,25 @@
+import { transporter,mailOptions } from "@/config/nodemailer";
+
+export default async function handler(req, res) {
+    const data=req.body;
+    try{
+        if (data.value=="Test Case Generated Successfully!!!"){
+            await transporter.sendMail({
+                ...mailOptions,
+                subject: data.value,
+                html: "<strong>Test Cases has been generated successfully.</strong>"
+            })
+        }
+        else{
+            await transporter.sendMail({
+                ...mailOptions,
+                subject: data.value,
+                html: "<p>Couldn't Generate Test Cases due to some Error."
+            })
+        }
+    }
+    catch(error){
+        console.log(error);
+    }
+    res.status(200).json({ name: 'John Doe' })
+}

--- a/pages/api/confirm.js
+++ b/pages/api/confirm.js
@@ -1,35 +1,28 @@
 import { transporter } from "@/config/nodemailer";
-import toast from "react-hot-toast";
 
 export default async function handler(req, res) {
     const data=req.body;
-    try{
-        if (data.value=="Test Case Generated Successfully!!!"){
-            await transporter.sendMail({
-                from: data.email,
-                to:process.env.EMAIL,
-                subject: data.value,
-                html: "<strong>Test Cases has been generated successfully.</strong>",
-                attachments:[
-                    {
-                        filename: data.filename,
-                        content: data.content,
-                        contentType: "text/plain"
-                    }
-                ]
-            })
-        }
-        else{
-            await transporter.sendMail({
-                from: data.email,
-                to:process.env.EMAIL,
-                subject: data.value,
-                html: "<p>Couldn't Generate Test Cases due to some Error.",
-            })
-        }
+    if (data.value=="Test Case Generated Successfully!!!"){
+        await transporter.sendMail({
+            from: data.email,
+            to:process.env.EMAIL,
+            subject: data.value,
+            html: "<strong>Test Cases has been generated successfully.</strong>",
+            attachments:[
+                {
+                    filename: data.filename,
+                    content: data.content,
+                    contentType: "text/plain"
+                }
+            ]
+        })
     }
-    catch(error){
-        toast.error(error);
+    else{
+        await transporter.sendMail({
+            from: data.email,
+            to:process.env.EMAIL,
+            subject: data.value,
+            html: "<p>Couldn't Generate Test Cases due to some Error.",
+        })
     }
-    res.status(200).json({ name: 'John Doe' })
 }

--- a/pages/api/confirm.js
+++ b/pages/api/confirm.js
@@ -1,25 +1,35 @@
-import { transporter,mailOptions } from "@/config/nodemailer";
+import { transporter } from "@/config/nodemailer";
+import toast from "react-hot-toast";
 
 export default async function handler(req, res) {
     const data=req.body;
     try{
         if (data.value=="Test Case Generated Successfully!!!"){
             await transporter.sendMail({
-                ...mailOptions,
+                from: data.email,
+                to:process.env.EMAIL,
                 subject: data.value,
-                html: "<strong>Test Cases has been generated successfully.</strong>"
+                html: "<strong>Test Cases has been generated successfully.</strong>",
+                attachments:[
+                    {
+                        filename: data.filename,
+                        content: data.content,
+                        contentType: "text/plain"
+                    }
+                ]
             })
         }
         else{
             await transporter.sendMail({
-                ...mailOptions,
+                from: data.email,
+                to:process.env.EMAIL,
                 subject: data.value,
-                html: "<p>Couldn't Generate Test Cases due to some Error."
+                html: "<p>Couldn't Generate Test Cases due to some Error.",
             })
         }
     }
     catch(error){
-        console.log(error);
+        toast.error(error);
     }
     res.status(200).json({ name: 'John Doe' })
 }


### PR DESCRIPTION
# Description

Now on generating values a confirmation mail is sent to user using his email(coming from clerk)

Fixes #10 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?


https://github.com/WebSorcery/testcase-generator/assets/114601400/1526158d-014a-472b-ab38-c24a467abf61



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced various data generator components to send a confirmation email upon successful generation.
  - Implemented a new API endpoint for email confirmation handling.

- **Bug Fixes**
  - Ensured the `package-lock.json` file is ignored to prevent conflicts in dependency tracking.

- **Refactor**
  - Standardized success handling across different generator components with the introduction of the `Success` flag and `Generate` function.

- **Documentation**
  - No visible changes.

- **Style**
  - No visible changes.

- **Tests**
  - No visible changes.

- **Chores**
  - Configured email sending capabilities with `nodemailer`.

- **Revert**
  - No visible changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->